### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ kubectl config current-context
 If you are running MacOS and use [homebrew] you can install **kubefwd** directly from the [txn2] tap:
 
 ```bash
-brew install txn2/tap/kubefwd
+brew install kubefwd
 ```
 
 To upgrade:


### PR DESCRIPTION
Brew suggested that I use `brew install kubefwd`
I got the following error
`Error: No available formula or cask with the name "txn2/tap/kubefwd".
==> Searching for similarly named formulae...
This similarly named formula was found:
kubefwd
To install it, run:
  brew install kubefwd`